### PR TITLE
Fix squashed commit messages

### DIFF
--- a/lib/worker/batcher/message.ex
+++ b/lib/worker/batcher/message.ex
@@ -189,7 +189,11 @@ defmodule BorsNG.Worker.Batcher.Message do
     end
   end
 
-  def generate_squash_commit_message(pr, commits, user_email, cut_body_after) do
+  def generate_squash_commit_title(pr) do
+    "#{pr.title} (##{pr.number})"
+  end
+
+  def generate_squash_commit_body(pr, commits, user_email, cut_body_after) do
     message_body = cut_body(pr.body, cut_body_after)
 
     co_authors =
@@ -199,7 +203,11 @@ defmodule BorsNG.Worker.Batcher.Message do
       |> Enum.uniq()
       |> Enum.join("\n")
 
-    "#{pr.title} (##{pr.number})\n\n#{message_body}\n\n#{co_authors}\n"
+    "#{message_body}\n\n#{co_authors}\n"
+  end
+
+  def generate_squash_commit_message(pr, commits, user_email, cut_body_after) do
+    "#{generate_squash_commit_title(pr)}\n\n#{generate_squash_commit_body(pr, commits, user_email, cut_body_after)}"
   end
 
   def generate_commit_message(


### PR DESCRIPTION
In https://github.com/MercuryTechnologies/bors-ng/pull/1 I added support for squash merging PRs in such a way that they are marked merged, but in the course of doing so I broke the generated commit message.  Specifically, the things I broke were:

- The commit message no longer includes the original PR number

- The commit message doesn't respect the `cut_body_after` option

- The commit message uses the default message generated by GitHub

  … which will typically be the ugly list of commit titles/descriptions rather than the nicer message based off of the PR description.

All three of these things broke for the same reason: `bors-ng` formats the commit title/message when generate commits for the staging branch, but we no longer reuse that staging branch when the batch is accepted.  Instead, the change from
https://github.com/MercuryTechnologies/bors-ng/pull/1 just squash merges the original PR without massaging the title or description, which leads to these issues.

The fix is to reuse the same logic that `bors-ng` created for generating commit messages on the staging branch to also generate commit messages when squash merging the original PR.  This should fix all of the above issues.