### PR TITLE
Accept PRs which push new commits to fix build failures

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -991,6 +991,12 @@ defmodule BorsNG.Worker.Batcher do
   end
 
   defp patch_preflight(repo_conn, patch, {:ok, toml}) do
+    # We need to get the latest state of the patch to make sure that we're
+    # checking the most recent commit for statuses.  Otherwise, if the user has
+    # a build failure and pushes new commits to fix the build failure then those
+    # fixes won't get picked up by the preflight check.
+    patch = Repo.get!(Patch, patch.id)
+
     passed_label =
       repo_conn
       |> GitHub.get_labels!(patch.pr_xref)


### PR DESCRIPTION
In 74776068b5b82faac807673d8fc0c7ba5a3083e3 I implemented support for `bors-ng` to wait in a manner similar to GitHub's auto-merge functionality.  However, that still did not work correctly in the following scenario, where:

- The user comments "bors merge" before checks pass
- One of the checks fails
- The user pushes a new commit to fix the failure

Before this change `bors-ng` would wait indefinitely (until timing out) in the above scenario because it would keep checking statuses for the last commit on the user's branch before they said "bors merge".  If the user added new commits those would not be checked by `bors-ng` so it would keep thinking that the branch was not passing status checks.

The fix is to update the `patch` variable to reflect new information gleaned since the preflight checks began (specifically, the latest commit) so that when the branch finally passes checks it is accepted into the queue.