### PR TITLE
Don't accept PRs which are in draft status

### DIFF
--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -1045,14 +1045,18 @@ defmodule BorsNG.Worker.Batcher do
         :sufficient
       end
 
-    pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
+    draft =
+      case GitHub.get_pr(repo_conn, patch.pr_xref) do
+        {:ok, pr} -> pr.draft
+        _ -> false
+      end
 
     Logger.info(
-      "Code review status: Label Check #{passed_label} Passed Status: #{no_error_status and no_waiting_status and no_unset_status} Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved} Passed Up-To-Date Review: #{passed_up_to_date_review} Not Draft: #{!pr.draft}"
+      "Code review status: Label Check #{passed_label} Passed Status: #{no_error_status and no_waiting_status and no_unset_status} Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved} Passed Up-To-Date Review: #{passed_up_to_date_review} Not Draft: #{!draft}"
     )
 
     case {passed_label, no_error_status, no_waiting_status, no_unset_status, passed_review,
-          code_owners_approved, passed_up_to_date_review, !pr.draft} do
+          code_owners_approved, passed_up_to_date_review, !draft} do
       {true, true, true, true, :sufficient, true, :sufficient, true} -> {:ok, toml.max_batch_size}
       {false, _, _, _, _, _, _, _} -> {:error, :blocked_labels}
       {_, _, _, _, _, _, _, _} -> :waiting

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -1045,18 +1045,12 @@ defmodule BorsNG.Worker.Batcher do
         :sufficient
       end
 
-    draft =
-      case GitHub.get_pr(repo_conn, patch.pr_xref) do
-        {:ok, pr} -> pr.draft
-        _ -> false
-      end
-
     Logger.info(
-      "Code review status: Label Check #{passed_label} Passed Status: #{no_error_status and no_waiting_status and no_unset_status} Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved} Passed Up-To-Date Review: #{passed_up_to_date_review} Not Draft: #{!draft}"
+      "Code review status: Label Check #{passed_label} Passed Status: #{no_error_status and no_waiting_status and no_unset_status} Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved} Passed Up-To-Date Review: #{passed_up_to_date_review} Not Draft: #{!patch.is_draft}"
     )
 
     case {passed_label, no_error_status, no_waiting_status, no_unset_status, passed_review,
-          code_owners_approved, passed_up_to_date_review, !draft} do
+          code_owners_approved, passed_up_to_date_review, !patch.is_draft} do
       {true, true, true, true, :sufficient, true, :sufficient, true} -> {:ok, toml.max_batch_size}
       {false, _, _, _, _, _, _, _} -> {:error, :blocked_labels}
       {_, _, _, _, _, _, _, _} -> :waiting

--- a/lib/worker/batcher.ex
+++ b/lib/worker/batcher.ex
@@ -1045,15 +1045,17 @@ defmodule BorsNG.Worker.Batcher do
         :sufficient
       end
 
+    pr = GitHub.get_pr!(repo_conn, patch.pr_xref)
+
     Logger.info(
-      "Code review status: Label Check #{passed_label} Passed Status: #{no_error_status and no_waiting_status and no_unset_status} Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved} Passed Up-To-Date Review: #{passed_up_to_date_review}"
+      "Code review status: Label Check #{passed_label} Passed Status: #{no_error_status and no_waiting_status and no_unset_status} Passed Review: #{passed_review} CODEOWNERS: #{code_owners_approved} Passed Up-To-Date Review: #{passed_up_to_date_review} Not Draft: #{!pr.draft}"
     )
 
     case {passed_label, no_error_status, no_waiting_status, no_unset_status, passed_review,
-          code_owners_approved, passed_up_to_date_review} do
-      {true, true, true, true, :sufficient, true, :sufficient} -> {:ok, toml.max_batch_size}
-      {false, _, _, _, _, _, _} -> {:error, :blocked_labels}
-      {_, _, _, _, _, _, _} -> :waiting
+          code_owners_approved, passed_up_to_date_review, !pr.draft} do
+      {true, true, true, true, :sufficient, true, :sufficient, true} -> {:ok, toml.max_batch_size}
+      {false, _, _, _, _, _, _, _} -> {:error, :blocked_labels}
+      {_, _, _, _, _, _, _, _} -> :waiting
     end
   end
 


### PR DESCRIPTION
This fixes both a UX issue and a correctness issue

The UX improvement is that a draft PR is one that is probably not ready for inclusion.  It should be moved out of draft status.

The correctness issue is that if squash merging is enabled then the squash merge via GitHub's API will fail if the PR is still in draft status.